### PR TITLE
Added Pagination and PaginationLink components

### DIFF
--- a/Blazorade.Bootstrap.Components.Showroom/Paginations.razor
+++ b/Blazorade.Bootstrap.Components.Showroom/Paginations.razor
@@ -67,16 +67,17 @@
 
 
 @code{
+    // Note: If you set the "Text" property, then any child content will be overwritten!
     List<ILink> customLinks = new List<ILink>
-{
-        new Link {Text = "Previous", Index = int.MinValue, Url = "#" },
-        new Link {Text = "1", Index = 1, Url = "#", IsActive = true },
-        new Link {Text = "2", Index = 2, Url = "#" },
-        new Link {Text = "3", Index = 3, Url = "#" },
-        new Link {Text = "4", Index = 4, Url = "#" },
-        new Link {Text = "5", Index = 5, Url = "#" },
-        new Link {Text = "6", Index = 6, Url = "#" },
-        new Link {Text = "Next", Index = int.MaxValue, Url = "#" }
+    {
+        new Link {Index = int.MinValue, Url = "#" },
+        new Link {Index = 1, Url = "#", IsActive = true },
+        new Link {Index = 2, Url = "#" },
+        new Link {Index = 3, Url = "#" },
+        new Link {Index = 4, Url = "#" },
+        new Link {Index = 5, Url = "#" },
+        new Link {Index = 6, Url = "#" },
+        new Link {Index = int.MaxValue, Url = "#" }
     };
 
     private void Previous()
@@ -112,7 +113,8 @@
 <Heading Id="advanced-pagination" IsAnchor="true" Level="HeadingLevel.H3" MarginTop="@headingMarginTop">Pagination with PaginationLink components</Heading>
 <Paragraph>
     This Pagination example makes use of child PaginationLink elements instead of simply a list of links, as well as some logic for handling moving the IsActive property. 
-    This includes use of the Clicked property to bind to methods, as well as the Index property, to order the links and mark the Previous and Next buttons.
+    This includes use of the Clicked property to bind to methods, as well as the Index property, to order the links and mark the Previous and Next buttons, 
+    and child content inside of the PaginationLink component to further customize the page buttons.
 </Paragraph>
 
 <Pagination>
@@ -120,15 +122,21 @@
     {
         if (link.Index == int.MinValue)
         {
-            <PaginationLink Url="@link.Url" Clicked="this.Previous">@link.Text</PaginationLink>
+            <PaginationLink Url="@link.Url" Clicked="this.Previous">
+                <Span aria-hidden="true">&laquo;</Span>
+            </PaginationLink>
         }
         else if (link.Index == int.MaxValue)
         {
-            <PaginationLink Url="@link.Url" Clicked="this.Next">@link.Text</PaginationLink>
+            <PaginationLink Url="@link.Url" Clicked="this.Next">
+                <Span aria-hidden="true">&raquo;</Span>
+            </PaginationLink>
         }
         else
         {
-            <PaginationLink Url="@link.Url" IsActive="link.IsActive" Clicked="@(() => MakePageActive(link))">@link.Text</PaginationLink>
+            <PaginationLink Url="@link.Url" IsActive="link.IsActive" Clicked="@(() => MakePageActive(link))">
+                <span style="color: @(link.IsActive ? "#F00" : "cornflowerblue")">@link.Index.ToString()</span>
+            </PaginationLink>
         }
     }
 </Pagination>

--- a/Blazorade.Bootstrap.Components.Showroom/Paginations.razor
+++ b/Blazorade.Bootstrap.Components.Showroom/Paginations.razor
@@ -122,19 +122,19 @@
     {
         if (link.Index == int.MinValue)
         {
-            <PaginationLink Url="@link.Url" Clicked="this.Previous">
+            <PaginationLink Link="@link" Clicked="this.Previous">
                 <Span aria-hidden="true">&laquo;</Span>
             </PaginationLink>
         }
         else if (link.Index == int.MaxValue)
         {
-            <PaginationLink Url="@link.Url" Clicked="this.Next">
+            <PaginationLink Link="@link" Clicked="this.Next">
                 <Span aria-hidden="true">&raquo;</Span>
             </PaginationLink>
         }
         else
         {
-            <PaginationLink Url="@link.Url" IsActive="link.IsActive" Clicked="@(() => MakePageActive(link))">
+            <PaginationLink Link="@link" Clicked="@(() => MakePageActive(link))">
                 <span style="color: @(link.IsActive ? "#F00" : "cornflowerblue")">@link.Index.ToString()</span>
             </PaginationLink>
         }

--- a/Blazorade.Bootstrap.Components.Showroom/Paginations.razor
+++ b/Blazorade.Bootstrap.Components.Showroom/Paginations.razor
@@ -1,7 +1,134 @@
 ﻿
+@code {
+    Spacing headingMarginTop = Spacing.Five;
+}
+
 <Heading Level="HeadingLevel.H2">Pagination Component</Heading>
 <Paragraph>
     The <Anchor Url="https://getbootstrap.com/docs/4.4/components/pagination/" OpenInNewTab="true">Pagination component</Anchor> is used to create pagination to indicate that a series of related content exists across multiple pages.
 </Paragraph>
 
 <DocsSection ComponentName="Pagination" />
+
+@code{
+    List<ILink> basicLinks = new List<ILink>
+{
+        new Link { Text = "Previous", Url = "#" },
+        new Link { Text = "1", Url = "#" },
+        new Link { Text = "2", Url = "#" },
+        new Link { Text = "3", Url = "#" },
+        new Link { Text = "Next", Url = "#" },
+    };
+}
+
+<Heading Id="basic-pagination" IsAnchor="true" Level="HeadingLevel.H3" MarginTop="@headingMarginTop">Basic Pagination</Heading>
+<Paragraph>
+    A basic Pagination example.
+</Paragraph>
+
+<Pagination Items="@basicLinks" />
+
+
+
+@code{
+    List<ILink> disabledAndActiveLinks = new List<ILink>
+{
+        new Link { Text = "Previous", Url = "#" },
+        new Link { Text = "1", Url = "#", IsActive = true},
+        new Link { Text = "2", Url = "#" },
+        new Link { Text = "3", Url = "#", IsDisabled = true},
+        new Link { Text = "Next", Url = "#" },
+    };
+}
+
+<Heading Id="active-disabled-pagination" IsAnchor="true" Level="HeadingLevel.H3" MarginTop="@headingMarginTop">Pagination with Active and Disabled links</Heading>
+<Paragraph>
+    A Pagination example with active and disabled links.
+</Paragraph>
+
+<Pagination Items="@disabledAndActiveLinks" />
+
+
+<Heading Id="small-pagination" IsAnchor="true" Level="HeadingLevel.H3" MarginTop="@headingMarginTop">Small Pagination</Heading>
+<Paragraph>
+    A Pagination example with the Size property set to PaginationSize.Small.
+</Paragraph>
+
+<Pagination Items="@basicLinks" Size="PaginationSize.Small" />
+
+
+<Heading Id="large-pagination" IsAnchor="true" Level="HeadingLevel.H3" MarginTop="@headingMarginTop">Large Pagination</Heading>
+<Paragraph>
+    A Pagination example with the Size property set to PaginationSize.Large.
+</Paragraph>
+
+<Pagination Items="@basicLinks" Size="PaginationSize.Large" />
+
+
+
+@code{
+    List<ILink> customLinks = new List<ILink>
+{
+        new Link {Text = "Previous", Index = int.MinValue, Url = "#" },
+        new Link {Text = "1", Index = 1, Url = "#", IsActive = true },
+        new Link {Text = "2", Index = 2, Url = "#" },
+        new Link {Text = "3", Index = 3, Url = "#" },
+        new Link {Text = "4", Index = 4, Url = "#" },
+        new Link {Text = "5", Index = 5, Url = "#" },
+        new Link {Text = "6", Index = 6, Url = "#" },
+        new Link {Text = "Next", Index = int.MaxValue, Url = "#" }
+    };
+
+    private void Previous()
+    {
+        var currentActive = customLinks.Where(l => l.IsActive).First();
+        if (currentActive.Index != 1)
+        {
+            customLinks.Where(l => currentActive.Index - 1 == l.Index).First().IsActive = true;
+            currentActive.IsActive = false;
+        }
+        this.StateHasChanged();
+    }
+
+    private void Next()
+    {
+        var currentActive = customLinks.Where(l => l.IsActive).First();
+        if (currentActive.Index != 6)
+        {
+            customLinks.Where(l => currentActive.Index + 1 == l.Index).First().IsActive = true;
+            currentActive.IsActive = false;
+        }
+        this.StateHasChanged();
+    }
+
+    private void MakePageActive(ILink item)
+    {
+        customLinks.Where(l => l.IsActive).First().IsActive = false;
+        item.IsActive = true;
+        this.StateHasChanged();
+    }
+}
+
+<Heading Id="advanced-pagination" IsAnchor="true" Level="HeadingLevel.H3" MarginTop="@headingMarginTop">Pagination with PaginationLink components</Heading>
+<Paragraph>
+    This Pagination example makes use of child PaginationLink elements instead of simply a list of links, as well as some logic for handling moving the IsActive property. 
+    This includes use of the Clicked property to bind to methods, as well as the Index property, to order the links and mark the Previous and Next buttons.
+</Paragraph>
+
+<Pagination>
+    @foreach (var link in customLinks.OrderBy(l => l.Index))
+    {
+        if (link.Index == int.MinValue)
+        {
+            <PaginationLink Url="@link.Url" Clicked="this.Previous">@link.Text</PaginationLink>
+        }
+        else if (link.Index == int.MaxValue)
+        {
+            <PaginationLink Url="@link.Url" Clicked="this.Next">@link.Text</PaginationLink>
+        }
+        else
+        {
+            <PaginationLink Url="@link.Url" IsActive="link.IsActive" Clicked="@(() => MakePageActive(link))">@link.Text</PaginationLink>
+        }
+    }
+</Pagination>

--- a/Blazorade.Bootstrap.Components.Showroom/Paginations.razor
+++ b/Blazorade.Bootstrap.Components.Showroom/Paginations.razor
@@ -134,7 +134,7 @@
         }
         else
         {
-            <PaginationLink Link="@link" Clicked="@(() => MakePageActive(link))">
+            <PaginationLink Link="@link" Clicked="@(() => this.MakePageActive(link))">
                 <span style="color: @(link.IsActive ? "#F00" : "cornflowerblue")">@link.Index.ToString()</span>
             </PaginationLink>
         }

--- a/Blazorade.Bootstrap.Components/ClassNames.cs
+++ b/Blazorade.Bootstrap.Components/ClassNames.cs
@@ -409,6 +409,34 @@ namespace Blazorade.Bootstrap.Components
             public const string Nav = "nav";
         }
 
+        public static class Paginations
+        {
+            /// <summary>
+            /// Add this class to mark an element as the container of page items
+            /// </summary>
+            public const string Pagination = "pagination";
+
+            /// <summary>
+            /// Add this class to mark an element as a page item, for use inside of a pagination element.
+            /// </summary>
+            public const string Item = "page-item";
+
+            /// <summary>
+            /// Add this class to an element inside of a page item to mark it as a link to another page in the pagination.
+            /// </summary>
+            public const string Link = "page-link";
+
+            /// <summary>
+            /// Add this class to a pagination element to make it large.
+            /// </summary>
+            public const string Large = "pagination-lg";
+
+            /// <summary>
+            /// Add this class to a pagination element to make it small.
+            /// </summary>
+            public const string Small = "pagination-sm";
+        }
+
         public static class Paragraphs
         {
             /// <summary>

--- a/Blazorade.Bootstrap.Components/Pagination.razor
+++ b/Blazorade.Bootstrap.Components/Pagination.razor
@@ -1,0 +1,18 @@
+﻿@inherits BootstrapComponentBase
+<nav>
+    <ul @attributes="this.Attributes">
+        @foreach(var item in this.Items)
+        {
+        <li class="page-item @( item.IsActive ? "active" : "") @( item.IsDisabled ? "disabled" : "")">
+            @if (null != this.ItemTemplate)
+            {
+                this.ItemTemplate(item);
+            }
+            else if (!string.IsNullOrEmpty(item.Url))
+            {
+                <Anchor Link="@item"></Anchor>
+            }
+        </li>
+        }
+    </ul>
+</nav>

--- a/Blazorade.Bootstrap.Components/Pagination.razor
+++ b/Blazorade.Bootstrap.Components/Pagination.razor
@@ -1,18 +1,18 @@
 ﻿@inherits BootstrapComponentBase
 <nav>
     <ul @attributes="this.Attributes">
-        @foreach(var item in this.Items)
+        @if (this.Items?.Count() > 0)
         {
-        <li class="page-item @( item.IsActive ? "active" : "") @( item.IsDisabled ? "disabled" : "")">
-            @if (null != this.ItemTemplate)
+            foreach (var item in this.Items)
             {
-                this.ItemTemplate(item);
+            <li class="page-item @( item.IsActive ? "active" : "") @( item.IsDisabled ? "disabled" : "")">
+                <Anchor Link="@item" class="page-link"></Anchor>
+            </li>
             }
-            else if (!string.IsNullOrEmpty(item.Url))
-            {
-                <Anchor Link="@item"></Anchor>
-            }
-        </li>
+        }
+        else
+        {
+            @this.ChildContent
         }
     </ul>
 </nav>

--- a/Blazorade.Bootstrap.Components/Pagination.razor.cs
+++ b/Blazorade.Bootstrap.Components/Pagination.razor.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Blazorade.Bootstrap.Components.Model;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+
+namespace Blazorade.Bootstrap.Components
+{
+    /// <summary>
+    /// The Pagination component allows you to supply a set of links and display a bootstrap pagination bar on the screen.
+    /// </summary>
+    public partial class Pagination
+    {
+
+        /// <summary>
+        /// Set the size of the pagination component. Defaults to "Normal"
+        /// </summary>
+        [Parameter]
+        public PaginationSize Size { get; set; } = PaginationSize.Normal;
+
+        /// <summary>
+        /// Create your own template using the <see cref="ILink"/> interface.
+        /// </summary>
+        [Parameter]
+        public RenderFragment<ILink> ItemTemplate { get; set; }
+
+        /// <summary>
+        /// A list of <see cref="ILink"/> objects to use as page links.
+        /// These MUST have the Url field populated to show up in the pagination!
+        /// </summary>
+        [Parameter]
+        public IReadOnlyList<ILink> Items { get; set; }
+
+
+        protected override void OnParametersSet()
+        {
+            this.AddClasses(ClassNames.Paginations.Pagination);
+
+            if(this.Size == PaginationSize.Large)
+            {
+                this.AddClasses(ClassNames.Paginations.Large);
+            }
+
+            if (this.Size == PaginationSize.Small)
+            {
+                this.AddClasses(ClassNames.Paginations.Small);
+            }
+
+            base.OnParametersSet();
+        }
+
+        
+    }
+
+    public enum PaginationSize
+    {
+        Normal,
+        Large,
+        Small
+    }
+}

--- a/Blazorade.Bootstrap.Components/Pagination.razor.cs
+++ b/Blazorade.Bootstrap.Components/Pagination.razor.cs
@@ -20,12 +20,6 @@ namespace Blazorade.Bootstrap.Components
         public PaginationSize Size { get; set; } = PaginationSize.Normal;
 
         /// <summary>
-        /// Create your own template using the <see cref="ILink"/> interface.
-        /// </summary>
-        [Parameter]
-        public RenderFragment<ILink> ItemTemplate { get; set; }
-
-        /// <summary>
         /// A list of <see cref="ILink"/> objects to use as page links.
         /// These MUST have the Url field populated to show up in the pagination!
         /// </summary>

--- a/Blazorade.Bootstrap.Components/Pagination.razor.cs
+++ b/Blazorade.Bootstrap.Components/Pagination.razor.cs
@@ -47,10 +47,24 @@ namespace Blazorade.Bootstrap.Components
         
     }
 
+    /// <summary>
+    /// Bootstrap Pagination sizes
+    /// </summary>
     public enum PaginationSize
     {
+        /// <summary>
+        /// The "normal" size for a bootstrap Pagination element. This is the default.
+        /// </summary>
         Normal,
+
+        /// <summary>
+        /// The "large" size for a bootstrap Pagination element.
+        /// </summary>
         Large,
+
+        /// <summary>
+        /// The "small" size for a bootstrap Pagination element.
+        /// </summary>
         Small
     }
 }

--- a/Blazorade.Bootstrap.Components/PaginationLink.razor
+++ b/Blazorade.Bootstrap.Components/PaginationLink.razor
@@ -1,0 +1,14 @@
+﻿@inherits Anchor
+
+<li class="page-item @( this.IsActive ? "active" : "") @( this.IsDisabled ? "disabled" : "")">
+    <a @attributes="this.Attributes" class="page-link" @onclick="this.OnClickedAsync">
+        @if(!string.IsNullOrEmpty(this.Text))
+        {
+            @this.Text
+        }
+        else
+        {
+            @this.ChildContent
+        }
+    </a>
+</li>

--- a/Blazorade.Bootstrap.Components/PaginationLink.razor.cs
+++ b/Blazorade.Bootstrap.Components/PaginationLink.razor.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Blazorade.Bootstrap.Components
+{
+    /// <summary>
+    /// The PaginationLink component represents the list item/anchor structure of a bootstrap "page-item" and "page-link".
+    ///  It must be used as a child element of a Pagination component, and can either make use of a bound <see cref="ILink"/>'s 
+    ///  "Text" property, a custom-defined "Text" property, or define its own child content.
+    /// </summary>
+    /// <inheritdoc cref="Anchor"/>
+    public partial class PaginationLink
+    {
+    }
+}

--- a/Blazorade.Bootstrap.Components/PaginationLink.razor.cs
+++ b/Blazorade.Bootstrap.Components/PaginationLink.razor.cs
@@ -6,10 +6,9 @@ namespace Blazorade.Bootstrap.Components
 {
     /// <summary>
     /// The PaginationLink component represents the list item/anchor structure of a bootstrap "page-item" and "page-link".
-    ///  It must be used as a child element of a Pagination component, and can either make use of a bound <see cref="ILink"/>'s 
+    ///  It must be used as a child element of a <see cref="Pagination"/> component, and can either make use of a bound <see cref="ILink"/>'s 
     ///  "Text" property, a custom-defined "Text" property, or define its own child content.
     /// </summary>
-    /// <inheritdoc cref="Anchor"/>
     public partial class PaginationLink
     {
     }

--- a/ClientTestHost/wwwroot/index.html
+++ b/ClientTestHost/wwwroot/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
     <title>Blazorade Bootstrap Showroom for WebAssembly</title>
-    <base href="/" />
+    <base href="/Blazorade-Bootstrap/" />
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
 
     <!-- Start Single Page Apps for GitHub Pages -->

--- a/ClientTestHost/wwwroot/index.html
+++ b/ClientTestHost/wwwroot/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
     <title>Blazorade Bootstrap Showroom for WebAssembly</title>
-    <base href="/Blazorade-Bootstrap/" />
+    <base href="/" />
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
 
     <!-- Start Single Page Apps for GitHub Pages -->


### PR DESCRIPTION
Included in this pull request:

**In Blazorade.Bootstrap.Components**

ClassNames
- Added the Paginations class and subsequent bootstrap class string constants.

Pagination
- Created a component patterned closely on the Breadcrumb component, in that it can take in a list of ILinks and then emit a full bootstrap pagination element tree. This is the Pagination component at its simplest.
- The component also handles the Size property, which uses a PaginationSize enum.
- If no list of ILinks is bound to the component, it will instead render its child content, which is why I also created a...

PaginationLink
- This component exists as Razor only, and inherits the Anchor component. It follows roughly the pattern of the Anchor component's razor structure, but adds the <li> container that is required for the Pagination structure in bootstrap.
- This allows for some pretty gnarly use-cases, demonstrated in the Paginations screen in the showroom app.

**In Blazorade.Bootstrap.Components.Showroom**

Paginations screen
- Added demos of the basic functionality, roughly following the example at https://getbootstrap.com/docs/4.4/components/pagination/
- Also added a rather complex example that makes use of the PaginationLink component to create a dynamic Pagination control that could conceivably be used to control a custom carousel, or perhaps the contents of an iframe. 