### PR TITLE
Added Popovers to Blazorade

### DIFF
--- a/Blazorade.Bootstrap.Components.Showroom/Host/Shared/MainMenu.razor
+++ b/Blazorade.Bootstrap.Components.Showroom/Host/Shared/MainMenu.razor
@@ -36,6 +36,7 @@
                 new MenuItem { Text = "Media", Url = "media", Description = "The Media component is used to build complex and repetitive content where media is positioned alongside content." },
                 new MenuItem { Text = "Sizing", Url = "sizing" },
                 new MenuItem { Text = "Grid", Url = "grids", Description = "Use the powerful grid system to build mobile-first layouts of all shapes and sizes." },
+                new MenuItem { Text = "Popovers", Url = "popovers", Description = "The popover component is used to push notifications to your visitor as a lighweight and customizable alert message." },
             }
         }
     };

--- a/Blazorade.Bootstrap.Components.Showroom/Popovers.razor
+++ b/Blazorade.Bootstrap.Components.Showroom/Popovers.razor
@@ -1,0 +1,34 @@
+﻿<Heading Level="HeadingLevel.H2">Popover Component</Heading>
+
+<Paragraph>
+    The <code>Popover</code> component creates lightweight, customizable alert notifications.
+</Paragraph>
+
+<DocsSection ComponentName="Toast" />
+
+
+@code {
+     Spacing headingTopMargin = Spacing.Five;
+
+    Popover popover1;
+    Popover popover2;
+    Popover popover3;
+
+
+
+}
+
+<Heading Id="handling-events" IsAnchor="true" Level="HeadingLevel.H3" MarginTop="@headingTopMargin">Handling Events</Heading>
+<Paragraph>
+    Couple samples below:
+</Paragraph>
+
+
+<Popover @ref="this.popover1"  Placement="right" Content="contents<br>More Content" Title="testing the title" Html="true" Trigger="hover"><a href="#" id="@this.popover1.TargetElementId">Popover Link</a></Popover>
+
+<Popover @ref="this.popover2" Placement="top" Content="hello<br>world" Title="title goes here" Html="true" Trigger="hover"><Button Color="NamedColor.Primary" IsOutline="true" Id="@this.popover2.TargetElementId">Popover button</Button></Popover>
+
+
+<Popover @ref="this.popover3" TargetElementId="SomeTestId" Placement="top" Content="some great content to display" Title="external button" Html="true" Trigger="hover"></Popover>
+
+<Button Color="NamedColor.Primary" IsOutline="true" Id="SomeTestId">External element</Button>

--- a/Blazorade.Bootstrap.Components/Blazorade.Bootstrap.Components.csproj
+++ b/Blazorade.Bootstrap.Components/Blazorade.Bootstrap.Components.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <RazorLangVersion>3.0</RazorLangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.9.6-preview</Version>
+    <Version>0.9.6.1-preview</Version>
     <Authors>Mika Berglund</Authors>
     <Company>Blazorade</Company>
     <Product>Blazorade Bootstrap</Product>
@@ -19,7 +19,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Blazorade.Core" Version="1.0.0" />
+    <PackageReference Include="Blazorade.Core" Version="0.9.1-preview" />
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Analyzers" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.0.0" />

--- a/Blazorade.Bootstrap.Components/ClassNames.cs
+++ b/Blazorade.Bootstrap.Components/ClassNames.cs
@@ -498,5 +498,14 @@ namespace Blazorade.Bootstrap.Components
 
             public const string Toast = "toast";
         }
+
+        public static class Popovers
+        {
+            public const string Body = "popover-body";
+
+            public const string Header = "popover-header";
+
+            public const string Popover = "popover";
+        }
     }
 }

--- a/Blazorade.Bootstrap.Components/EventNames.cs
+++ b/Blazorade.Bootstrap.Components/EventNames.cs
@@ -42,5 +42,16 @@ namespace Blazorade.Bootstrap.Components
 
             public const string Hidden = "hidden.bs.toast";
         }
+
+        public static class Popover
+        {
+            public const string Show = "show.bs.popover";
+
+            public const string Shown = "shown.bs.popover";
+
+            public const string Hide = "hide.bs.popover";
+
+            public const string Hidden = "hidden.bs.popover";
+        }
     }
 }

--- a/Blazorade.Bootstrap.Components/ExtensionMethods.cs
+++ b/Blazorade.Bootstrap.Components/ExtensionMethods.cs
@@ -48,5 +48,10 @@ namespace Blazorade.Bootstrap.Components
             return new ToastInterop(jsInterop);
         }
 
+
+        public static PopoverInterop Popover(this IJSRuntime jsInterop)
+        {
+            return new PopoverInterop(jsInterop);
+        }
     }
 }

--- a/Blazorade.Bootstrap.Components/JSInterop/PopoverInterop.cs
+++ b/Blazorade.Bootstrap.Components/JSInterop/PopoverInterop.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.JSInterop;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Blazorade.Bootstrap.Components.JSInterop
+{
+    public class PopoverInterop : ComponentInteropBase
+    {
+        public PopoverInterop(IJSRuntime interop) : base(interop)
+        {
+        }
+
+
+        public async Task HideAsync(string id)
+        {
+            await this.InteropRuntime.InvokeVoidAsync(JsFunctions.Popover.Hide, $"#{id}");
+        }
+
+        public async Task InitAsync(string id, string title, string content, bool html, int delay, string placement, string trigger, int offset)
+        {
+            await this.InteropRuntime.InvokeVoidAsync(JsFunctions.Popover.Init, $"#{id}", title, content, html, delay, placement, trigger, offset);
+        }
+
+        public async Task ShowAsync(string id)
+        {
+            await this.InteropRuntime.InvokeVoidAsync(JsFunctions.Popover.Show, $"#{id}");
+        }
+
+    }
+}

--- a/Blazorade.Bootstrap.Components/JsFunctions.cs
+++ b/Blazorade.Bootstrap.Components/JsFunctions.cs
@@ -78,6 +78,17 @@ namespace Blazorade.Bootstrap.Components
             public const string Toggle = ModalRoot + "toggle";
         }
 
+        public static class Popover
+        {
+            private const string ToastRoot = Root + "popovers.";
+
+            public const string Init = ToastRoot + "init";
+
+            public const string Show = ToastRoot + "show";
+
+            public const string Hide = ToastRoot + "hide";
+        }
+
         public static class Toast
         {
             private const string ToastRoot = Root + "toasts.";

--- a/Blazorade.Bootstrap.Components/Popover.razor
+++ b/Blazorade.Bootstrap.Components/Popover.razor
@@ -1,0 +1,4 @@
+﻿@inherits BootstrapComponentBase
+
+   
+        @this.ChildContent

--- a/Blazorade.Bootstrap.Components/Popover.razor.cs
+++ b/Blazorade.Bootstrap.Components/Popover.razor.cs
@@ -1,0 +1,207 @@
+﻿using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Blazorade.Bootstrap.Components
+{
+    partial class Popover
+    {
+
+        public Popover()
+        {
+            
+            this.Delay = 0;
+            this.Placement = "right";
+            this.Offset = 0;
+            this.Html = true;
+            this.Trigger = "click";
+            this.TargetElementId = GenerateNewId();
+
+
+        }
+
+
+
+        /// <summary>
+        /// The callback that is triggered when the Popover is about to hide.
+        /// </summary>
+        [Parameter]
+        public EventCallback<Popover> OnHide { get; set; }
+
+        /// <summary>
+        /// The callback that is triggered when the Popover has been completely hidden.
+        /// </summary>
+        [Parameter]
+        public EventCallback<Popover> OnHidden { get; set; }
+
+        /// <summary>
+        /// The callback that is triggered when the Popover is about to be shown.
+        /// </summary>
+        [Parameter]
+        public EventCallback<Popover> OnShow { get; set; }
+
+        /// <summary>
+        /// The callback that is called when the Popover as been completely shown.
+        /// </summary>
+        [Parameter]
+        public EventCallback<Popover> OnShown { get; set; }
+
+
+
+        /// <summary>
+        /// Specifies whether the Popover should automatically hide after the number of milliseconds specified in <see cref="Delay"/>.
+        /// </summary>
+        [Parameter]
+        public bool AutoHide { get; set; }
+        [Parameter]
+        public string TargetElementId { get; set; }
+
+        [Parameter]
+        public string Content { get; set; }
+
+        [Parameter]
+        public string Title { get; set; }
+
+        [Parameter]
+        public bool Html { get; set; }
+
+        [Parameter]
+        public string Placement { get; set; }
+
+        [Parameter]
+        public string Trigger { get; set; }
+
+
+        [Parameter]
+        public int Offset { get; set; }
+
+        [Parameter]
+        public RenderFragment BodyTemplate { get; set; }
+
+        [Parameter]
+        public int Delay { get; set; }
+
+        [Parameter]
+        public string Header { get; set; }
+
+        [Parameter]
+        public RenderFragment HeaderTemplate { get; set; }
+
+        /// <summary>
+        /// Specifies whether the hide button is shown in the header of the Popover.
+        /// </summary>
+        [Parameter]
+        public bool ShowHideButton { get; set; }
+
+        /// <summary>
+        /// Specifies whether to show the Popover immediately when rendered without having to separately invoke the <see cref="ShowAsync"/> method.
+        /// </summary>
+        [Parameter]
+        public bool ShowOnRender { get; set; }
+
+        [Parameter]
+        public string Subheader { get; set; }
+
+
+
+        public void Hide()
+        {
+            this.HideAsync();
+        }
+
+        public async Task HideAsync()
+        {
+            await this.JsInterop.Popover().HideAsync(this.Id);
+        }
+
+        public void Show()
+        {
+            this.ShowAsync();
+        }
+
+        public async Task ShowAsync()
+        {
+            await this.JsInterop.RegisterEventCallbackAsync(this.Id, EventNames.Popover.Show, this, nameof(this.OnShowAsync));
+            await this.JsInterop.RegisterEventCallbackAsync(this.Id, EventNames.Popover.Shown, this, nameof(this.OnShownAsync));
+            await this.JsInterop.RegisterEventCallbackAsync(this.Id, EventNames.Popover.Hide, this, nameof(this.OnHideAsync));
+            await this.JsInterop.RegisterEventCallbackAsync(this.Id, EventNames.Popover.Hidden, this, nameof(this.OnHiddenAsync));
+
+            await this.JsInterop.Popover().ShowAsync(this.Id);
+        }
+
+
+        protected override void OnParametersSet()
+        {
+           // this.AddClasses(ClassNames.Popovers.Popover);
+
+             //this.AddClasses(ClassNames.Hide);
+
+           // this.AddAttribute("role", "tooltip");
+            // this.AddAttribute("aria-live", "assertive");
+            // this.AddAttribute("aria-atomic", "true");
+
+            base.OnParametersSet();
+
+            this.SetIdIfEmpty();
+        }
+
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (firstRender)
+            {
+                if (this.TargetElementId == null) TargetElementId = this.Id;
+
+                await this.JsInterop.Popover().InitAsync(this.TargetElementId, this.Title, this.Content, this.Html, this.Delay, this.Placement, this.Trigger, this.Offset) ;
+                if (this.ShowOnRender)
+                {
+                    await this.JsInterop.Popover().ShowAsync(this.Id);
+                }
+            }
+
+            await base.OnAfterRenderAsync(firstRender);
+        }
+
+        /// <summary>
+        /// Triggers the <see cref="OnHide"/> callback.
+        /// </summary>
+        /// <remarks>Invoked by JS Interop. Not to be called directly.</remarks>
+        [JSInvokable]
+        public virtual async Task OnHideAsync()
+        {
+            await this.OnHide.InvokeAsync(this);
+        }
+
+        /// <summary>
+        /// Triggers the <see cref="OnHidden"/> callback.
+        /// </summary>
+        /// <remarks>Invoked by JS Interop. Not to be called directly.</remarks>
+        [JSInvokable]
+        public virtual async Task OnHiddenAsync()
+        {
+            await this.OnHidden.InvokeAsync(this);
+        }
+
+        /// <summary>
+        /// Triggers the <see cref="OnShow"/> callback.
+        /// </summary>
+        /// <remarks>Invoked by JS Interop. Not to be called directly.</remarks>
+        [JSInvokable]
+        public virtual async Task OnShowAsync()
+        {
+            await this.OnShow.InvokeAsync(this);
+        }
+
+        /// <summary>
+        /// Triggers the <see cref="OnShown"/> callback.
+        /// </summary>
+        /// <remarks>Invoked by JS Interop. Not to be called directly.</remarks>
+        [JSInvokable]
+        public virtual async Task OnShownAsync()
+        {
+            await this.OnShown.InvokeAsync(this);
+        }
+    }
+}

--- a/Blazorade.Bootstrap.Components/wwwroot/bbs.js
+++ b/Blazorade.Bootstrap.Components/wwwroot/bbs.js
@@ -118,5 +118,27 @@ window.blazoradeBootstrap = {
         }
     },
 
+    popovers: {
+        init: function (selector, title, content, html, delay, placement, trigger, offset) {
+           
+            $(selector).popover({
+                title: title,
+                content: content,
+                html:html,
+                delay: delay,
+                placement:placement,
+                trigger:trigger,
+                offset: offset
+
+            });
+        },
+        hide: function (selector) {
+            $(selector).popover("hide");
+        },
+        show: function (selector) {            
+            $(selector).popover("show");
+        }
+    },
+
     console: console
 };

--- a/ServerTestHost/Pages/Popovers.razor
+++ b/ServerTestHost/Pages/Popovers.razor
@@ -1,0 +1,3 @@
+﻿@page "/popovers"
+
+<Blazorade.Bootstrap.Components.Showroom.Popovers />


### PR DESCRIPTION
Added the code to handle bootstrap popovers into Blazorade.   Added a link in the top navigation "Work In Progress" called "Popovers" (yes, very clever I know).   There are 3 quick examples showing a couple different ways to attach the popover component to elements in the popovers.razor in the showroom:

<Popover @ref="this.popover1"  Placement="right" Content="contents<br>More Content" Title="testing the title" Html="true" Trigger="hover"><a href="#" id="@this.popover1.TargetElementId">Popover Link</a></Popover>

<Popover @ref="this.popover2" Placement="top" Content="hello<br>world" Title="title goes here" Html="true" Trigger="hover"><Button Color="NamedColor.Primary" IsOutline="true" Id="@this.popover2.TargetElementId">Popover button</Button></Popover>


<Popover @ref="this.popover3" TargetElementId="SomeTestId" Placement="top" Content="some great content to display" Title="external button" Html="true" Trigger="hover"></Popover>

<Button Color="NamedColor.Primary" IsOutline="true" Id="SomeTestId">External element</Button>


I used the toast components as the base, it looks like I can clean up some of the parameters that are specific to toasts and not needed in popovers, so apologize for leaving that in.  But, hopefully you get the idea in the direction I was taking this and find it useful.  