### PR TITLE
Fixed the DropdownItem component

### DIFF
--- a/Blazorade.Bootstrap.Components.Showroom/Navbars.razor
+++ b/Blazorade.Bootstrap.Components.Showroom/Navbars.razor
@@ -74,6 +74,10 @@
             <DropdownItem Text="Link 1" />
             <DropdownItem Text="Link 2" />
         </DropdownNavItem>
+        <DropdownNavItem Text="Components">
+            <DropdownItem Url="carousels">Carousel</DropdownItem>
+            <DropdownItem Url="spinners">Spinner</DropdownItem>
+        </DropdownNavItem>
     </NavbarNav>
     <NavbarNav MarginLeft="Spacing.Auto">
         <NavItem Item="@(new MenuItem { Text = "About", Url = "https://github.com/MikaBerglund/Blazor-Bootstrap/wiki", OpenInNewTab = true })" />

--- a/Blazorade.Bootstrap.Components/DropdownItem.cs
+++ b/Blazorade.Bootstrap.Components/DropdownItem.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace Blazorade.Bootstrap.Components
 {
-    public partial class DropdownItem
+    public partial class DropdownItem : Anchor
     {
 
         protected override void OnParametersSet()

--- a/Blazorade.Bootstrap.Components/DropdownItem.razor
+++ b/Blazorade.Bootstrap.Components/DropdownItem.razor
@@ -1,3 +1,0 @@
-﻿@inherits Anchor
-
-<Anchor @attributes="this.Attributes" Text="@this.Text" Clicked="this.Clicked">@this.ChildContent</Anchor>


### PR DESCRIPTION
The `Url` specified on the [DropdownItem](https://github.com/Blazorade/Blazorade-Bootstrap/wiki/DropdownItem) component was never written to the [Anchor](https://github.com/Blazorade/Blazorade-Bootstrap/wiki/Anchor) component that was actually used for rendering. Removed the unnecessary DropdownItem.razor file and set the DropdownItem component to directly inherit from Anchor without any UI markup.

Fixes #108 