### PR TITLE
Enable short version of Heading.Level

### DIFF
--- a/Blazorade.Bootstrap.Components.Showroom/Alerts.razor
+++ b/Blazorade.Bootstrap.Components.Showroom/Alerts.razor
@@ -1,7 +1,7 @@
 ﻿@code {
     Spacing headingMarginTop = Spacing.Five;
 }
-<Heading Level="HeadingLevel.H2">Alert Component</Heading>
+<Heading Level="2">Alert Component</Heading>
 
 <Paragraph>
     The <code>Alert</code> component is used to provide feedback messages, typically in response to user actions.
@@ -11,7 +11,7 @@
 <DocsSection ComponentName="Alert" />
 
 
-<Heading Id="standard-colours" IsAnchor="true" Level="HeadingLevel.H3" MarginTop="@headingMarginTop">Standard Colours</Heading>
+<Heading Id="standard-colours" IsAnchor="true" Level="3" MarginTop="@headingMarginTop">Standard Colours</Heading>
 <Paragraph>
     Alerts can be coloured with the named colours in Bootstrap.
 </Paragraph>
@@ -26,7 +26,7 @@
 
 
 
-<Heading Id="dismissible-alerts" IsAnchor="true" Level="HeadingLevel.H3" MarginTop="@headingMarginTop">Dismissible Alerts</Heading>
+<Heading Id="dismissible-alerts" IsAnchor="true" Level="3" MarginTop="@headingMarginTop">Dismissible Alerts</Heading>
 <Paragraph>
     Alerts can be configured as dismissible, which allows the user to dismiss an alert when it has been read.
 </Paragraph>
@@ -65,7 +65,7 @@
 
 
 
-<Heading Id="headings-and-links" IsAnchor="true" Level="HeadingLevel.H3" MarginTop="@headingMarginTop">Alerts with Headings and Links</Heading>
+<Heading Id="headings-and-links" IsAnchor="true" Level="3" MarginTop="@headingMarginTop">Alerts with Headings and Links</Heading>
 
 <Alert Color="NamedColor.Info">
     <HeadingTemplate>This is the heading</HeadingTemplate>

--- a/Blazorade.Bootstrap.Components.Tests/HeadingTests.cs
+++ b/Blazorade.Bootstrap.Components.Tests/HeadingTests.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Blazorade.Bootstrap.Components.Tests
+{
+    [TestClass]
+    public class HeadingTests
+    {
+
+        [TestMethod]
+        public void Level01()
+        {
+            Assert.AreEqual(1, HeadingLevel.H1.Value);
+            Assert.AreEqual(2, HeadingLevel.H2.Value);
+            Assert.AreEqual(3, HeadingLevel.H3.Value);
+            Assert.AreEqual(4, HeadingLevel.H4.Value);
+            Assert.AreEqual(5, HeadingLevel.H5.Value);
+            Assert.AreEqual(6, HeadingLevel.H6.Value);
+        }
+
+        [TestMethod]
+        public void Level02()
+        {
+            Assert.AreEqual(1, HeadingLevel.H1);
+            Assert.AreEqual(2, HeadingLevel.H2);
+            Assert.AreEqual(3, HeadingLevel.H3);
+            Assert.AreEqual(4, HeadingLevel.H4);
+            Assert.AreEqual(5, HeadingLevel.H5);
+            Assert.AreEqual(6, HeadingLevel.H6);
+        }
+
+        [TestMethod]
+        public void Level03()
+        {
+            Assert.AreEqual("1", HeadingLevel.H1);
+            Assert.AreEqual("2", HeadingLevel.H2);
+            Assert.AreEqual("3", HeadingLevel.H3);
+            Assert.AreEqual("4", HeadingLevel.H4);
+            Assert.AreEqual("5", HeadingLevel.H5);
+            Assert.AreEqual("6", HeadingLevel.H6);
+        }
+
+        [TestMethod]
+        public void Level04()
+        {
+            Assert.AreEqual("h1", HeadingLevel.H1);
+            Assert.AreEqual("h2", HeadingLevel.H2);
+            Assert.AreEqual("h3", HeadingLevel.H3);
+            Assert.AreEqual("h4", HeadingLevel.H4);
+            Assert.AreEqual("h5", HeadingLevel.H5);
+            Assert.AreEqual("h6", HeadingLevel.H6);
+        }
+
+        [TestMethod]
+        public void Level05()
+        {
+            Assert.AreEqual("H1", HeadingLevel.H1);
+            Assert.AreEqual("H2", HeadingLevel.H2);
+            Assert.AreEqual("H3", HeadingLevel.H3);
+            Assert.AreEqual("H4", HeadingLevel.H4);
+            Assert.AreEqual("H5", HeadingLevel.H5);
+            Assert.AreEqual("H6", HeadingLevel.H6);
+        }
+
+    }
+}

--- a/Blazorade.Bootstrap.Components/Blazorade.Bootstrap.Components.xml
+++ b/Blazorade.Bootstrap.Components/Blazorade.Bootstrap.Components.xml
@@ -2429,34 +2429,39 @@
             Defines different levels for headings.
             </summary>
         </member>
-        <member name="F:Blazorade.Bootstrap.Components.HeadingLevel.H1">
+        <member name="P:Blazorade.Bootstrap.Components.HeadingLevel.H1">
             <summary>
             First level.
             </summary>
         </member>
-        <member name="F:Blazorade.Bootstrap.Components.HeadingLevel.H2">
+        <member name="P:Blazorade.Bootstrap.Components.HeadingLevel.H2">
             <summary>
             Second level.
             </summary>
         </member>
-        <member name="F:Blazorade.Bootstrap.Components.HeadingLevel.H3">
+        <member name="P:Blazorade.Bootstrap.Components.HeadingLevel.H3">
             <summary>
             Third level.
             </summary>
         </member>
-        <member name="F:Blazorade.Bootstrap.Components.HeadingLevel.H4">
+        <member name="P:Blazorade.Bootstrap.Components.HeadingLevel.H4">
             <summary>
             Fourth level.
             </summary>
         </member>
-        <member name="F:Blazorade.Bootstrap.Components.HeadingLevel.H5">
+        <member name="P:Blazorade.Bootstrap.Components.HeadingLevel.H5">
             <summary>
             Fifth level.
             </summary>
         </member>
-        <member name="F:Blazorade.Bootstrap.Components.HeadingLevel.H6">
+        <member name="P:Blazorade.Bootstrap.Components.HeadingLevel.H6">
             <summary>
             Sixth level.
+            </summary>
+        </member>
+        <member name="P:Blazorade.Bootstrap.Components.HeadingLevel.Value">
+            <summary>
+            The actual value of the 
             </summary>
         </member>
         <member name="T:Blazorade.Bootstrap.Components.ImageBase">

--- a/Blazorade.Bootstrap.Components/Blazorade.Bootstrap.Components.xml
+++ b/Blazorade.Bootstrap.Components/Blazorade.Bootstrap.Components.xml
@@ -2429,6 +2429,16 @@
             Defines different levels for headings.
             </summary>
         </member>
+        <member name="M:Blazorade.Bootstrap.Components.HeadingLevel.op_Implicit(System.Int32)~Blazorade.Bootstrap.Components.HeadingLevel">
+            <summary>
+            Converts the given integer to <see cref="T:Blazorade.Bootstrap.Components.HeadingLevel"/>.
+            </summary>
+        </member>
+        <member name="M:Blazorade.Bootstrap.Components.HeadingLevel.op_Implicit(System.String)~Blazorade.Bootstrap.Components.HeadingLevel">
+            <summary>
+            Converts the given string to <see cref="T:Blazorade.Bootstrap.Components.HeadingLevel"/>.
+            </summary>
+        </member>
         <member name="P:Blazorade.Bootstrap.Components.HeadingLevel.H1">
             <summary>
             First level.

--- a/Blazorade.Bootstrap.Components/Heading.razor
+++ b/Blazorade.Bootstrap.Components/Heading.razor
@@ -1,28 +1,28 @@
 ﻿@inherits BootstrapComponentBase
 
-@switch (this.Level)
+@switch (this.Level.Value)
 {
-    case HeadingLevel.H1:
+    case HeadingLevel.H1Value:
         <h1 @attributes="this.Attributes"><HeadingContent HeadingId="@this.Id" IsAnchor="@this.IsAnchor">@this.ChildContent</HeadingContent></h1>
         break;
 
-    case HeadingLevel.H2:
+    case HeadingLevel.H2Value:
         <h2 @attributes="this.Attributes"><HeadingContent HeadingId="@this.Id" IsAnchor="@this.IsAnchor">@this.ChildContent</HeadingContent></h2>
         break;
 
-    case HeadingLevel.H3:
+    case HeadingLevel.H3Value:
         <h3 @attributes="this.Attributes"><HeadingContent HeadingId="@this.Id" IsAnchor="@this.IsAnchor">@this.ChildContent</HeadingContent></h3>
         break;
 
-    case HeadingLevel.H4:
+    case HeadingLevel.H4Value:
         <h4 @attributes="this.Attributes"><HeadingContent HeadingId="@this.Id" IsAnchor="@this.IsAnchor">@this.ChildContent</HeadingContent></h4>
         break;
 
-    case HeadingLevel.H5:
+    case HeadingLevel.H5Value:
         <h5 @attributes="this.Attributes"><HeadingContent HeadingId="@this.Id" IsAnchor="@this.IsAnchor">@this.ChildContent</HeadingContent></h5>
         break;
 
-    case HeadingLevel.H6:
+    case HeadingLevel.H6Value:
         <h6 @attributes="this.Attributes"><HeadingContent HeadingId="@this.Id" IsAnchor="@this.IsAnchor">@this.ChildContent</HeadingContent></h6>
         break;
 }

--- a/Blazorade.Bootstrap.Components/HeadingLevel.cs
+++ b/Blazorade.Bootstrap.Components/HeadingLevel.cs
@@ -3,36 +3,80 @@
     /// <summary>
     /// Defines different levels for headings.
     /// </summary>
-    public enum HeadingLevel
+    public struct HeadingLevel
     {
+
+        internal const int H1Value = 1;
+
+        internal const int H2Value = 2;
+
+        internal const int H3Value = 3;
+
+        internal const int H4Value = 4;
+
+        internal const int H5Value = 5;
+
+        internal const int H6Value = 6;
+
+
+
+
         /// <summary>
         /// First level.
         /// </summary>
-        H1 = 1,
+        public static HeadingLevel H1
+        {
+            get { return new HeadingLevel { Value = H1Value }; }
+        }
 
         /// <summary>
         /// Second level.
         /// </summary>
-        H2 = 2,
+        public static HeadingLevel H2
+        {
+            get { return new HeadingLevel { Value = H2Value }; }
+        }
 
         /// <summary>
         /// Third level.
         /// </summary>
-        H3 = 3,
+        public static HeadingLevel H3
+        {
+            get { return new HeadingLevel { Value = H3Value }; }
+        }
 
         /// <summary>
         /// Fourth level.
         /// </summary>
-        H4 = 4,
+        public static HeadingLevel H4
+        {
+            get { return new HeadingLevel { Value = H4Value }; }
+        }
 
         /// <summary>
         /// Fifth level.
         /// </summary>
-        H5 = 5,
+        public static HeadingLevel H5
+        {
+            get { return new HeadingLevel { Value = H5Value }; }
+        }
 
         /// <summary>
         /// Sixth level.
         /// </summary>
-        H6 = 6
+        public static HeadingLevel H6
+        {
+            get { return new HeadingLevel { Value = H6Value }; }
+        }
+
+
+
+        private int _Value;
+        /// <summary>
+        /// The actual value of the 
+        /// </summary>
+        public int Value { get { return _Value; } private set { _Value = value; } }
+
     }
+
 }

--- a/Blazorade.Bootstrap.Components/HeadingLevel.cs
+++ b/Blazorade.Bootstrap.Components/HeadingLevel.cs
@@ -99,7 +99,7 @@ namespace Blazorade.Bootstrap.Components
 
         private int _Value;
         /// <summary>
-        /// The actual value of the 
+        /// The actual value of the heading.
         /// </summary>
         public int Value { get { return _Value; } private set { _Value = value; } }
 

--- a/Blazorade.Bootstrap.Components/HeadingLevel.cs
+++ b/Blazorade.Bootstrap.Components/HeadingLevel.cs
@@ -1,4 +1,6 @@
-﻿namespace Blazorade.Bootstrap.Components
+﻿using System.Text.RegularExpressions;
+
+namespace Blazorade.Bootstrap.Components
 {
     /// <summary>
     /// Defines different levels for headings.
@@ -19,7 +21,31 @@
         internal const int H6Value = 6;
 
 
+        /// <summary>
+        /// Converts the given integer to <see cref="HeadingLevel"/>.
+        /// </summary>
+        public static implicit operator HeadingLevel(int i)
+        {
+            return new HeadingLevel { Value = i };
+        }
 
+        /// <summary>
+        /// Converts the given string to <see cref="HeadingLevel"/>.
+        /// </summary>
+        public static implicit operator HeadingLevel(string s)
+        {
+            if (int.TryParse(s, out int i))
+            {
+                return new HeadingLevel { Value = i };
+            }
+
+            var m = Regex.Match(s, "[Hh]\\d");
+            if (m.Success)
+            {
+                return m.Value.Substring(1);
+            }
+            return H1;
+        }
 
         /// <summary>
         /// First level.


### PR DESCRIPTION
Closes #104 

- Changed HeadingLevel from enum to struct
- Added enum members as static properties
- Created implicit conversion operators on the HeadingLevel struct to convert from integers and strings.
- Changed how heading levels are specified for Alerts on the showroom app.