### PR TITLE
Shorter syntax for Heading.Display with struct instead of enum

### DIFF
--- a/Blazorade.Bootstrap.Components.Showroom/Modals.razor
+++ b/Blazorade.Bootstrap.Components.Showroom/Modals.razor
@@ -41,7 +41,7 @@
 <Modal @ref="this.modal2" Header="Custom Header" Body="A dialog with a customized header. You can use any component or HTML element in your custom header. Note that if customizing a header, you also need to add the close button for the dialog. You can use the CloseModalButton component for that.">
     <HeaderTemplate>
         <ModalHeader BackgroundColor="NamedColor.Dark" TextColor="NamedColor.Light">
-            <Heading Level="HeadingLevel.H1" Display="HeadingDisplay.Display1">@context</Heading>
+            <Heading Level="HeadingLevel.H1" Display="1">@context</Heading>
             <CloseModalButton />
         </ModalHeader>
     </HeaderTemplate>
@@ -93,7 +93,7 @@
 <Modal @ref="this.modal5" Header="Custom Header">
     <HeaderTemplate>
         <ModalHeader BackgroundColor="NamedColor.Dark" TextColor="NamedColor.Light">
-            <Heading Level="HeadingLevel.H1" Display="HeadingDisplay.Display1">@context</Heading>
+            <Heading Level="HeadingLevel.H1" Display="1">@context</Heading>
             <CloseModalButton />
         </ModalHeader>
     </HeaderTemplate>

--- a/Blazorade.Bootstrap.Components/Blazorade.Bootstrap.Components.xml
+++ b/Blazorade.Bootstrap.Components/Blazorade.Bootstrap.Components.xml
@@ -2408,20 +2408,35 @@
             For details see <c>https://getbootstrap.com/docs/4.4/content/typography/#display-headings</c>.
             </remarks>
         </member>
-        <member name="F:Blazorade.Bootstrap.Components.HeadingDisplay.Display1">
+        <member name="M:Blazorade.Bootstrap.Components.HeadingDisplay.op_Implicit(System.Int32)~Blazorade.Bootstrap.Components.HeadingDisplay">
+            <summary>
+            Converts the given integer to a <see cref="T:Blazorade.Bootstrap.Components.HeadingDisplay"/> value.
+            </summary>
+        </member>
+        <member name="M:Blazorade.Bootstrap.Components.HeadingDisplay.op_Implicit(System.String)~Blazorade.Bootstrap.Components.HeadingDisplay">
+            <summary>
+            Convert the given string to a <see cref="T:Blazorade.Bootstrap.Components.HeadingDisplay"/> value.
+            </summary>
+        </member>
+        <member name="P:Blazorade.Bootstrap.Components.HeadingDisplay.D1">
             <summary>
             </summary>
         </member>
-        <member name="F:Blazorade.Bootstrap.Components.HeadingDisplay.Display2">
+        <member name="P:Blazorade.Bootstrap.Components.HeadingDisplay.D2">
             <summary>
             </summary>
         </member>
-        <member name="F:Blazorade.Bootstrap.Components.HeadingDisplay.Display3">
+        <member name="P:Blazorade.Bootstrap.Components.HeadingDisplay.D3">
             <summary>
             </summary>
         </member>
-        <member name="F:Blazorade.Bootstrap.Components.HeadingDisplay.Display4">
+        <member name="P:Blazorade.Bootstrap.Components.HeadingDisplay.D4">
             <summary>
+            </summary>
+        </member>
+        <member name="P:Blazorade.Bootstrap.Components.HeadingDisplay.Value">
+            <summary>
+            Actual value.
             </summary>
         </member>
         <member name="T:Blazorade.Bootstrap.Components.HeadingLevel">

--- a/Blazorade.Bootstrap.Components/Heading.razor.cs
+++ b/Blazorade.Bootstrap.Components/Heading.razor.cs
@@ -38,7 +38,7 @@ namespace Blazorade.Bootstrap.Components
         {
             if (this.Display.HasValue)
             {
-                this.AddClasses($"display-{(int)this.Display}");
+                this.AddClasses($"display-{(int)this.Display.Value.Value}");
             }
 
 

--- a/Blazorade.Bootstrap.Components/HeadingDisplay.cs
+++ b/Blazorade.Bootstrap.Components/HeadingDisplay.cs
@@ -1,27 +1,64 @@
 ﻿namespace Blazorade.Bootstrap.Components
 {
+
     /// <summary>
     /// Allows you to make a Heading stand out as a larger than normal heading.
     /// </summary>
     /// <remarks>
     /// For details see <c>https://getbootstrap.com/docs/4.4/content/typography/#display-headings</c>.
     /// </remarks>
-    public enum HeadingDisplay
+    public struct HeadingDisplay
     {
+
+        internal const int D1Value = 1;
+        internal const int D2Value = 2;
+        internal const int D3Value = 3;
+        internal const int D4Value = 4;
+
+
         /// <summary>
+        /// Converts the given integer to a <see cref="HeadingDisplay"/> value.
         /// </summary>
-        Display1 = 1,
+        public static implicit operator HeadingDisplay(int i)
+        {
+            if(i >= D1Value && i <= D4Value)
+            {
+                return new HeadingDisplay { Value = i };
+            }
+            return new HeadingDisplay { Value = D1Value };
+        }
+
+        /// <summary>
+        /// Convert the given string to a <see cref="HeadingDisplay"/> value.
+        /// </summary>
+        public static implicit operator HeadingDisplay(string s)
+        {
+            if(int.TryParse(s, out int i))
+            {
+                return i;
+            }
+            return new HeadingDisplay { Value = 1 };
+        }
 
         /// <summary>
         /// </summary>
-        Display2 = 2,
+        public static HeadingDisplay D1 { get { return new HeadingDisplay { Value = D1Value }; } }
 
         /// <summary>
         /// </summary>
-        Display3 = 3,
+        public static HeadingDisplay D2 { get { return new HeadingDisplay { Value = D2Value }; } }
 
         /// <summary>
         /// </summary>
-        Display4 = 4
+        public static HeadingDisplay D3 { get { return new HeadingDisplay { Value = D3Value }; } }
+
+        /// <summary>
+        /// </summary>
+        public static HeadingDisplay D4 { get { return new HeadingDisplay { Value = D4Value }; } }
+
+        /// <summary>
+        /// Actual value.
+        /// </summary>
+        public int Value { get; private set; }
     }
 }

--- a/Blazorade.Bootstrap.Components/Jumbotron.razor
+++ b/Blazorade.Bootstrap.Components/Jumbotron.razor
@@ -7,7 +7,7 @@
     }
     else
     {
-        <Heading Level="HeadingLevel.H1" Display="HeadingDisplay.Display4">@this.Heading</Heading>
+        <Heading Level="HeadingLevel.H1" Display="4">@this.Heading</Heading>
     }
 
     @if(null != this.LeadTemplate)

--- a/ClientTestHost/Pages/Index.razor
+++ b/ClientTestHost/Pages/Index.razor
@@ -1,6 +1,6 @@
 ﻿@page "/"
 
-<Heading Level="HeadingLevel.H1" Display="HeadingDisplay.Display3">Blazorade Bootstrap Showroom</Heading>
+<Heading Level="HeadingLevel.H1" Display="3">Blazorade Bootstrap Showroom</Heading>
 
 <Paragraph>
     This is a Blazor WebAssembly application demonstrating the use of the <a href="https://github.com/Blazorade/Blazorade-Bootstrap">Blazorade Bootstrap</a> component library.


### PR DESCRIPTION
- Changed HeadingDisplay from enum to struct
- Created implicit converter operators for struct to convert from both int and string

All samples below are now valid.

``` HTML
<Heading Display="HeadingDisplay.D1">Heading</Heading>
<Heading Display="1">Heading</Heading>
```

Closes #111